### PR TITLE
Add CI workflow for core and optional dashboard tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,75 @@
+name: test
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  core:
+    name: Core tests (dev only)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - run: python -V
+      - run: pip install -U pip wheel setuptools
+
+      # ⚠️ Ne pas installer requirements.txt ni deps privées
+      - run: pip install -e .[dev]
+
+      - name: Run pytest (core)
+        run: pytest -q
+        env:
+          ENABLE_DASHBOARD: "false"
+          PYTHONWARNINGS: default
+
+  dashboard:
+    name: Dashboard tests (extras)
+    needs: core
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - run: pip install -U pip wheel setuptools
+      - run: pip install -e .[dashboard,dev]
+
+      - name: Run pytest (dashboard)
+        run: pytest -q
+        env:
+          ENABLE_DASHBOARD: "true"
+          DASHBOARD_AUTH: "disabled"
+          DASHBOARD_PORT: "5000"
+          PYTHONWARNINGS: default

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -q

--- a/tests/test_dashboard_endpoints.py
+++ b/tests/test_dashboard_endpoints.py
@@ -1,5 +1,13 @@
 from datetime import datetime
 
+import importlib.util
+import pytest
+
+flask_spec = importlib.util.find_spec("flask")
+dash_spec = importlib.util.find_spec("dash")
+if flask_spec is None or dash_spec is None:
+    pytest.skip("Dashboard dependencies not installed", allow_module_level=True)
+
 from ai_trader.dashboard import server
 
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow with separate core and dashboard jobs using Python 3.11
- ensure dashboard tests skip when Flask/Dash extras absent
- run pytest quietly via pytest.ini

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cdd0c34f0832dab625cb8e62c5e13